### PR TITLE
feat: 카카오 oAuth 인가코드 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,16 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+	testImplementation 'io.projectreactor:reactor-test'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// FOR @ConfigurationProperties
+tasks.named('compileJava') {
+	inputs.files(tasks.named('processResources'))
 }

--- a/src/main/java/CloudComputingD/DBox/Application.java
+++ b/src/main/java/CloudComputingD/DBox/Application.java
@@ -2,8 +2,10 @@ package CloudComputingD.DBox;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/CloudComputingD/DBox/controller/OauthController.java
+++ b/src/main/java/CloudComputingD/DBox/controller/OauthController.java
@@ -1,0 +1,37 @@
+package CloudComputingD.DBox.controller;
+
+import CloudComputingD.DBox.service.OauthService;
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+@RestController
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @SneakyThrows
+    @GetMapping("/{oauthServerType}")
+    ResponseEntity<Void> redirectAuthCodeRequestUrl(
+            @PathVariable OauthServerType oauthServerType,
+            HttpServletResponse response
+    ) {
+        String redirectUrl = oauthService.getAuthCodeRequestUrl(oauthServerType);
+        response.sendRedirect(redirectUrl);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/{oauthServerType}")
+    ResponseEntity<String> login(
+            @PathVariable OauthServerType oauthServerType,
+            @RequestParam("code") String code
+    ) {
+        String login = oauthService.login(oauthServerType, code);
+        return ResponseEntity.ok(login);
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/common/config/WebConfig.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/common/config/WebConfig.java
@@ -1,0 +1,35 @@
+package CloudComputingD.DBox.oauth.common.config;
+
+import CloudComputingD.DBox.oauth.presentation.OauthServerTypeConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    //CORS 설정, localhost:3000이 react 프론트가 될 예정
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.DELETE.name(),
+                        HttpMethod.PATCH.name()
+                )
+                .allowCredentials(true)
+                .exposedHeaders("*");
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new OauthServerTypeConverter());
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/domain/OauthServerType.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/domain/OauthServerType.java
@@ -1,0 +1,14 @@
+package CloudComputingD.DBox.oauth.domain;
+
+import java.util.Locale;
+
+//"kakao"를 통해 OauthServerType.KAKAO를 찾아오기 위해 fromName() 이라는 메서드를 구현
+public enum OauthServerType {
+
+    KAKAO,
+    ;
+
+    public static OauthServerType fromName(String type) {
+        return OauthServerType.valueOf(type.toUpperCase(Locale.ENGLISH));
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/domain/authcode/AuthCodeRequestUrlProvider.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/domain/authcode/AuthCodeRequestUrlProvider.java
@@ -1,0 +1,9 @@
+package CloudComputingD.DBox.oauth.domain.authcode;
+
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+
+//여러 서비스에게 인가 코드를 받아오기 위한 URL 제공 인터페이스
+public interface AuthCodeRequestUrlProvider {
+    OauthServerType supportServer();
+    String provide();
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/domain/authcode/AuthCodeRequestUrlProviderComposite.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/domain/authcode/AuthCodeRequestUrlProviderComposite.java
@@ -1,0 +1,34 @@
+package CloudComputingD.DBox.oauth.domain.authcode;
+
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+@Component
+public class AuthCodeRequestUrlProviderComposite {
+
+    private final Map<OauthServerType, AuthCodeRequestUrlProvider> mapping;
+
+    public AuthCodeRequestUrlProviderComposite(Set<AuthCodeRequestUrlProvider> providers) {
+        mapping = providers.stream()
+                .collect(toMap(
+                        AuthCodeRequestUrlProvider::supportServer,
+                        identity()
+                ));
+    }
+
+    public String provide(OauthServerType oauthServerType) {
+        return getProvider(oauthServerType).provide();
+    }
+
+    private AuthCodeRequestUrlProvider getProvider(OauthServerType oauthServerType) {
+        return Optional.ofNullable(mapping.get(oauthServerType))
+                .orElseThrow(() -> new RuntimeException("지원하지 않는 소셜 로그인 타입입니다."));
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/infra/oauth/kakao/KakaoOauthConfig.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/infra/oauth/kakao/KakaoOauthConfig.java
@@ -1,0 +1,12 @@
+package CloudComputingD.DBox.oauth.infra.oauth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOauthConfig(
+        String redirectUri,
+        String clientId,
+        String clientSecret,
+        String[] scope
+) {
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/infra/oauth/kakao/authcode/KakaoAuthCodeRequestUrlProvider.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/infra/oauth/kakao/authcode/KakaoAuthCodeRequestUrlProvider.java
@@ -1,0 +1,31 @@
+package CloudComputingD.DBox.oauth.infra.oauth.kakao.authcode;
+
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+import CloudComputingD.DBox.oauth.domain.authcode.AuthCodeRequestUrlProvider;
+import CloudComputingD.DBox.oauth.infra.oauth.kakao.KakaoOauthConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthCodeRequestUrlProvider implements AuthCodeRequestUrlProvider {
+
+    private final KakaoOauthConfig kakaoOauthConfig;
+
+    @Override
+    public OauthServerType supportServer() {
+        return OauthServerType.KAKAO;
+    }
+
+    @Override
+    public String provide() {
+        return UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakaoOauthConfig.clientId())
+                .queryParam("redirect_uri", kakaoOauthConfig.redirectUri())
+                .queryParam("scope", String.join(",", kakaoOauthConfig.scope()))
+                .toUriString();
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/oauth/presentation/OauthServerTypeConverter.java
+++ b/src/main/java/CloudComputingD/DBox/oauth/presentation/OauthServerTypeConverter.java
@@ -1,0 +1,11 @@
+package CloudComputingD.DBox.oauth.presentation;
+
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+import org.springframework.core.convert.converter.Converter;
+
+public class OauthServerTypeConverter implements Converter<String, OauthServerType> {
+    @Override
+    public OauthServerType convert(String source) {
+        return OauthServerType.fromName(source);
+    }
+}

--- a/src/main/java/CloudComputingD/DBox/service/OauthService.java
+++ b/src/main/java/CloudComputingD/DBox/service/OauthService.java
@@ -1,0 +1,29 @@
+package CloudComputingD.DBox.service;
+
+import CloudComputingD.DBox.entity.User;
+import CloudComputingD.DBox.repository.OauthMemberRepository;
+import CloudComputingD.DBox.oauth.domain.OauthServerType;
+import CloudComputingD.DBox.oauth.domain.authcode.AuthCodeRequestUrlProviderComposite;
+import CloudComputingD.DBox.oauth.domain.client.OauthMemberClientComposite;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
+    private final OauthMemberClientComposite oauthMemberClientComposite;
+    private final OauthMemberRepository oauthMemberRepository;
+
+    public String getAuthCodeRequestUrl(OauthServerType oauthServerType) {
+        return authCodeRequestUrlProviderComposite.provide(oauthServerType);
+    }
+
+    public String login(OauthServerType oauthServerType, String authCode) {
+        User user = oauthMemberClientComposite.fetch(oauthServerType, authCode);
+        User saved = oauthMemberRepository.findByOauthId(user.oauthId())
+                .orElseGet(() -> oauthMemberRepository.save(user));
+        return saved.oauthId().oauthServerId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: TRACE
+
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/test;AUTO_SERVER=TRUE
+    username: splguyjr
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+        highlight_sql: true
+
+    hibernate:
+      ddl-auto: update
+
+oauth:
+  kakao:
+    client_id: ${api-key} # REST API ?
+    redirect_uri: http://localhost:3000/oauth/redirected/kakao
+    client_secret: ${secret-key} # Client Secret ?
+    scope: profile_nickname, profile_image


### PR DESCRIPTION
frontend에서 카카오톡 로그인 버튼 클릭 -> backend oauth/kakao로 GET요청
->backend에서 kakao api정보를 담은 url를 생성하여 redirect -> frontend에서 인가코드 get